### PR TITLE
Two edits to remove errors caused by new versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ nginx:
   log_driver: 'fluentd'
   log_opt:
     fluentd-address: localhost:24224
-    fluentd-tag: docker.{{.FullID}}
+    tag: docker.{{.FullID}}
 node_app:
   build: node_app/
   links:
@@ -39,4 +39,4 @@ node_app:
   log_driver: 'fluentd'
   log_opt:
     fluentd-address: localhost:24224
-    fluentd-tag: docker.{{.FullID}}
+    tag: docker.{{.FullID}}

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -7,6 +7,4 @@ RUN chmod +x /tmp/entrypoint.sh
 
 COPY config/kibana.yml /opt/kibana/config/kibana.yml
 
-RUN kibana plugin --install elastic/sense
-
 CMD ["/tmp/entrypoint.sh"]


### PR DESCRIPTION
Why:

* kibana was faling because sense is now include by default
(https://discuss.elastic.co/t/cannot-install-kibana-plugin-sense/64950)

* ERROR: for node_app  Cannot create container for service node_app:
  unknown log opt 'fluentd-tag' for fluentd log driver

What:

* Remove the sense install line
* remove fluentd- from fluentd-tag

Remaining issues:

node_app_1       | WARNING: no logs are available with the 'fluentd' log
driver
nginx_1          | WARNING: no logs are available with the 'fluentd' log
driver

efk_elasticsearch_1 exited with code 64