### PR TITLE
Fixed activate elasticsearch container

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,21 @@ docker-compose up -d
 
 ```sh
 docker-compose ps
-          Name                         Command               State                Ports
------------------------------------------------------------------------------------------------------
-dockerefk_elasticsearch_1   /docker-entrypoint.sh elas ...   Up      0.0.0.0:9200->9200/tcp, 9300/tcp
-dockerefk_fluentd_1         sh -c /tmp/entrypoint.sh         Up      0.0.0.0:24224->24224/tcp
-dockerefk_kibana_1          /docker-entrypoint.sh /tmp ...   Up      0.0.0.0:5601->5601/tcp
-dockerefk_nginx_1           sh -c /tmp/entrypoint.sh         Up      443/tcp, 0.0.0.0:80->80/tcp
-dockerefk_node_app_1        sh -c /tmp/entrypoint.sh         Up      0.0.0.0:8080->8080/tcp
+    Name                   Command               State                 Ports
+-------------------------------------------------------------------------------------------
+elasticsearch   /docker-entrypoint.sh elas ...   Up      0.0.0.0:9200->9200/tcp, 9300/tcp
+fluentd         sh -c /tmp/entrypoint.sh         Up      0.0.0.0:24224->24224/tcp, 5140/tcp
+kibana          /docker-entrypoint.sh /tmp ...   Up      0.0.0.0:5601->5601/tcp
+nginx           sh -c /tmp/entrypoint.sh         Up      443/tcp, 0.0.0.0:80->80/tcp
+node_app        sh -c /tmp/entrypoint.sh         Up      0.0.0.0:8080->8080/tcp
 ```
 
 ```sh
 # open kibana
-open http://localhot:5601
+open http://127.0.0.1:5601
 
 # if use docker-machine
 open http://"$(docker-machine ip dev)":5601
 ```
 
 If you use docker-toolbox, localhost is docker-machine ip.
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 elasticsearch:
   image: elasticsearch:latest
-  command: elasticsearch -Des.network.host=0.0.0.0
+  container_name: elasticsearch
   ports:
     - '9200:9200'
 kibana:
+  container_name: kibana
   build: kibana/
   volumes:
     - ./kibana/config/kibana.yml:/opt/kibana/config/kibana.yml
@@ -12,6 +13,7 @@ kibana:
   links:
     - elasticsearch
 fluentd:
+  container_name: fluentd
   build: fluentd/
   volumes:
     - /var/lib/docker/containers:/var/lib/docker/containers
@@ -20,6 +22,7 @@ fluentd:
   ports:
     - '24224:24224'
 nginx:
+  container_name: nginx
   build: nginx/
   links:
     - fluentd
@@ -31,6 +34,7 @@ nginx:
     fluentd-address: localhost:24224
     tag: docker.{{.FullID}}
 node_app:
+  container_name: node_app
   build: node_app/
   links:
     - fluentd


### PR DESCRIPTION
### Summary


Fix start command because elasticsearch container is not running.
I deleted start command to bind to localhost's address by default from 5.0.

Also, I decided to attach a container name.

### Other Information

See. https://hub.docker.com/_/elasticsearch/
